### PR TITLE
fix: use getManagers() as of Symfony 2.1

### DIFF
--- a/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
+++ b/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
@@ -545,7 +545,7 @@ class DoctrineStatsCollector extends DataCollector implements DoctrineCollectorI
     {
         $return = [];
         /** @var EntityManagerInterface $entityManager */
-        foreach ($this->doctrine->getEntityManagers() as $entityManager) {
+        foreach ($this->doctrine->getManagers() as $entityManager) {
             foreach ($entityManager->getUnitOfWork()->getIdentityMap() as $class => $entities) {
                 $return[$class] = [
                     'count' => count($entities),

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     },
     "require": {
         "php" : "^5.4.0 || ^7.0",
-        "doctrine/orm": "^2.4.8"
+        "doctrine/orm": "^2.4.8",
+        "symfony/doctrine-bridge": ">=2.1"
     },
     "suggest": {
         "steevanb/composer-overload-class ^1.0": "Add hydration time to statistics",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,12 @@
     "require": {
         "php" : "^5.4.0 || ^7.0",
         "doctrine/orm": "^2.4.8",
-        "symfony/doctrine-bridge": ">=2.1"
+        
     },
     "suggest": {
         "steevanb/composer-overload-class ^1.0": "Add hydration time to statistics",
-        "steevanb/php-backtrace ^1.1": "Add backtrace to queries"
+        "steevanb/php-backtrace ^1.1": "Add backtrace to queries",
+        "symfony/doctrine-bridge >=2.1": "To use with Symfony"
     },
     "repositories": [
         {


### PR DESCRIPTION
<img width="1082" alt="screen shot 2017-08-30 at 13 34 43" src="https://user-images.githubusercontent.com/319498/29872642-5d5fee00-8d88-11e7-966b-06410a1b7707.png">

This drops support for anything < Symfony 2.1, I assume that isn't a big deal given its not a supported Symfony release anyway.

I've added a composer rule to flag it anyway, so should be clear.