### PR TITLE
Compatibility with Symfony5 & Doctrine 3 & PHP8

### DIFF
--- a/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
+++ b/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
@@ -2,7 +2,7 @@
 
 namespace steevanb\DoctrineStats\Bridge\DoctrineStatsBundle\DataCollector;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use steevanb\DoctrineStats\Bridge\DoctrineCollectorInterface;
 use steevanb\DoctrineStats\Doctrine\DBAL\Logger\SqlLogger;

--- a/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
+++ b/Bridge/DoctrineStatsBundle/DataCollector/DoctrineStatsCollector.php
@@ -184,7 +184,7 @@ class DoctrineStatsCollector extends DataCollector implements DoctrineCollectorI
      * @param Response $response
      * @param \Exception|null $exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
         $this->data = [
             'lazyLoadedEntities' => $this->lazyLoadedEntities,

--- a/Bridge/DoctrineStatsBundle/DependencyInjection/Configuration.php
+++ b/Bridge/DoctrineStatsBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('doctrine_stats');
+        $treeBuilder = new TreeBuilder('doctrine_stats');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('doctrine_stats');
 
         $rootNode
             ->children()

--- a/Bridge/DoctrineStatsBundle/Resources/views/DataCollector/template.html.twig
+++ b/Bridge/DoctrineStatsBundle/Resources/views/DataCollector/template.html.twig
@@ -265,18 +265,18 @@
                             {{ queries.data|length }}
                         </span>
                     </td>
-                    <td class="nowrap">{% spaceless %}
+                    <td class="nowrap">{% apply spaceless %}
                         {% if queries.lazyLoadedEntities|length > 0 %}
                             <span class="badge metric-red">Lazy loading</span>
                         {% else %}
                             Manual
                         {% endif %}
-                    {% endspaceless %}</td>
-                    <td class="nowrap">{% spaceless %}
+                    {% endapply %}</td>
+                    <td class="nowrap">{% apply spaceless %}
                         <img src="http://www.dustball.com/icons/icons/database.png" title="SQL time" /> {{ '%0.2f'|format(queries.queryTime) }}&nbsp;ms ({{ queries.queryTimePercent }}%)<br />
                         <img src="http://www.dustball.com/icons/icons/page_white_php.png" title="Hydration time" /> {{ '%0.2f'|format(queries.hydrationTime) }}&nbsp;ms ({{ queries.hydrationTimePercent }}%)<br />
                         <img src="http://www.dustball.com/icons/icons/time.png" title="Total time" /> {{ '%0.2f'|format(queries.queryTime + queries.hydrationTime) }}&nbsp;ms
-                    {% endspaceless %}</td>
+                    {% endapply %}</td>
                     <td>
                         <div>{{ sql|doctrine_pretty_query(highlight_only = true) }}</div>
 
@@ -510,10 +510,10 @@
 {% endblock %}
 
 {% macro className(classNameParts) %}
-    {% spaceless %}
+    {% apply spaceless %}
         <span class="text-muted">{{ classNameParts.namespace }}\</span>
         <span class="text-bold">{{ classNameParts.className }}</span>
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {% macro identifiers(collector, identifiers, merged = false) %}

--- a/README.md
+++ b/README.md
@@ -69,27 +69,28 @@ If you want to add hydration time to your statistics :
 composer update steevanb/composer-overload-class
 ```
 
-### Symfony 2.x, 3.x and 4.x integration
+### Symfony integration
 
 Read Installation paragraph before.
 
+#### Symfony 2.x, 3.x and 4.x
+
+_Use version 1.3.x of this bundle._
+
+#### Symfony 5.x
+
 ```php
-### app/AppKernel.php
-class AppKernel
-{
-    public function registerBundles()
-    {
-        if ($this->getEnvironment() === 'dev') {
-            $bundles[] = new \steevanb\DoctrineStats\Bridge\DoctrineStatsBundle\DoctrineStatsBundle();
-        }
-    }
-}
+### config/bundles.php
+return [
+    // ...
+    \steevanb\DoctrineStats\Bridge\DoctrineStatsBundle\DoctrineStatsBundle::class => ['dev' => true],
+];
 ```
 
-If you want to add lazy loaded entities to your statistics :
+If you want to add lazy loaded entities to your statistics:
 
 ```yml
-### app/config/config_dev.yml
+### config/services_dev.yaml (you may have to create that file)
 parameters:
     doctrine.orm.entity_manager.class: steevanb\DoctrineStats\Doctrine\ORM\EntityManager
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
             "steevanb\\DoctrineStats\\EventSubscriber\\": "EventSubscriber"
         }
     },
+    "config": {
+        "doctrine/persistence": "<1.3"
+    },
     "require": {
         "php" : "^5.4.0 || ^7.0",
         "doctrine/orm": "^2.4.8"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/persistence": "<1.3"
     },
     "require": {
-        "php" : "^5.4.0 || ^7.0",
+        "php" : "^5.4.0 || ^7.0 || ^8.0",
         "doctrine/orm": "^2.4.8"
     },
     "suggest": {


### PR DESCRIPTION
Hello,

This PR adds compatibility with Symfony & latest version of Twig. Amongst modifications, `RegistryInterface` was removed (https://github.com/symfony/symfony/issues/32394), Twig removed `spaceless` tag.  I updated documentation.
BC is unfortunately broken: `DataCollectorInterface` was modified in a backward-incompatible way. 
Since we don't require `symfony/symfony` in `composer.json`, I can't restrict this modification to Symfony 5 only. So I suppose it should be released in a new major version.

*edited on 16/03/2021: PHP8 compatibility was added*